### PR TITLE
Menu tests

### DIFF
--- a/src/_support/Page/Acceptance/Administrator/ArticleManagerPage.php
+++ b/src/_support/Page/Acceptance/Administrator/ArticleManagerPage.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * @package     Joomla.Test
+ * @subpackage  AcceptanceTester.Page
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Page\Acceptance\Administrator;
+
+/**
+ * Acceptance Page object class to define Content Manager page objects.
+ *
+ * @package  Page\Acceptance\Administrator
+ *
+ * @since    __DEPLOY_VERSION__
+ */
+class ArticleManagerPage extends AdminPage
+{
+	/**
+	 * Drop Down Toggle Element.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $dropDownToggle = ['xpath' => "//button[contains(@class, 'dropdown-toggle')]"];
+
+	/**
+	 * Page object for content body editor field.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $content = ['id' => 'jform_articletext'];
+
+	/**
+	 * Page object for the toggle button.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $toggleEditor = "Toggle editor";
+
+	/**
+	 * Link to the article listing page.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $url = "/administrator/index.php?option=com_content&view=articles";
+
+	/**
+	 * Locator for article's name field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $seeName = ['xpath' => "//table[@id='articleList']//tr[1]//td[4]"];
+
+	/**
+	 * Locator for article's featured icon
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $seeFeatured = ['xpath' => "//table[@id='articleList']//*//span[@class='icon-featured']"];
+
+	/**
+	 * Locator for article's name field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $seeAccessLevel = ['xpath' => "//table[@id='articleList']//tr[1]//td[5]"];
+
+	/**
+	 * Locator for article's unpublish icon
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $seeUnpublished = ['xpath' => "//table[@id='articleList']//*//span[@class='icon-unpublish']"];
+
+	/**
+	 * Method to create new article
+	 *
+	 * @param   string  $title    The article title
+	 * @param   string  $content  The article content
+	 *
+	 * @When    I create new content with field title as :title and content as a :content
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function fillContentCreateForm($title, $content)
+	{
+		$I = $this;
+
+		$I->fillField(self::$title, $title);
+		$I->scrollTo(['css' => 'div.toggle-editor']);
+		$I->click(self::$toggleEditor);
+		$I->fillField(self::$content, $content);
+	}
+
+	/**
+     * Locator for selecting Article's category
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+	public static $selectCategory = ['xpath' => "//div[@id='jform_catid_chzn']"];
+
+    /**
+     * Locator for selecting Article's category
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     * The input doesn't have any id or class so I had to use tree structure for xpath
+     */
+	public static $fillCategory = ['xpath' => '//*[@id="jform_catid_chzn"]/div/div/input'];
+}

--- a/src/_support/Page/Acceptance/Administrator/MenuItem.php
+++ b/src/_support/Page/Acceptance/Administrator/MenuItem.php
@@ -9,7 +9,7 @@
      *  7.0.30
      */
 
-namespace Page\Acceptance\Administrator;
+    namespace Page\Acceptance\Administrator;
 
     /**
      * Acceptance Page object class to menu items page objects.
@@ -19,10 +19,10 @@ namespace Page\Acceptance\Administrator;
      * @since __DEPLOY_VERSION__
      */
 
-class MenuItem
-{
+    class MenuItem
+    {
         // include url of current page
-    public static $url = "administrator/index.php?option=com_menus&view=items";
+        public static $url = "administrator/index.php?option=com_menus&view=items";
 
         /**
          * New User Button
@@ -30,7 +30,7 @@ class MenuItem
          * @var   string
          * @since 3.7.3
          */
-    public static $newButton = ['id' => 'toolbar-new'];
+        public static $newButton = ['id' => 'toolbar-new'];
 
         /**
          * Menu Item Title
@@ -38,7 +38,7 @@ class MenuItem
          * @var   string
          * @since 3.7.3
          */
-    public static $menuItemTitle = ['id' => 'jform_title'];
+        public static $menuItemTitle = ['id' => 'jform_title'];
 
         /**
          * Menu Item Alias
@@ -46,7 +46,7 @@ class MenuItem
          * @var   string
          * @since 3.7.3
          */
-    public static $menuItemAlias = ['id' => 'jform_alias'];
+        public static $menuItemAlias = ['id' => 'jform_alias'];
 
         /**
          * Menu Item Save
@@ -54,7 +54,7 @@ class MenuItem
          * @var   string
          * @since 3.7.3
          */
-    public static  $saveButton = ['id' => 'toolbar-apply'];
+        public static  $saveButton = ['id' => 'toolbar-apply'];
 
         /**
          * Page title of the user manager listing page.
@@ -62,7 +62,7 @@ class MenuItem
          * @var   string
          * @since 3.7.3
          */
-    public static $pageTitleText = "Menus";
+        public static $pageTitleText = "Menus";
 
 
         /**
@@ -71,7 +71,7 @@ class MenuItem
          * @var   string
          * @since 3.7.3
          */
-    public static $menuDropDown = ['xpath' => '//select[@id="jform_menutype"]'];
+        public static $menuDropDown = ['id' => 'jform_menutype'];
 
         /**
          * Selecting option from dropdown menu
@@ -79,37 +79,52 @@ class MenuItem
          * @var   string
          * @since 3.7.3
          */
-    public static $selectOption = ['xpath' => '//select[@id="jform_menutype"]/option[@value="mainmenu"]'];
+        public static $selectOption = ['xpath' => '//select[@id="jform_menutype"]/option[@value="mainmenu"]'];
 
-          /**
-           * Select  the checkbox status
-           *
-           * @var   string
-           * @since __DEPLOY_VERSION__
-           */
-    public static $check = ['id' => 'cb0'];
+       /**
+        * Select  the checkbox status
+        *
+        * @var   string
+        * @since __DEPLOY_VERSION__
+        */
+        public static $check = ['id' => 'cb0'];
 
 
-    public static $menuTypeModal = ['id' => 'menuTypeModal'];
+        public static $menuTypeModal = ['id' => 'menuTypeModal'];
 
-    public static $articlesLink = ['link' => 'Articles'];
+        public static $articlesLink = ['link' => 'Articles'];
 
-    public static $archiveArticles = ['link' => 'Archived Articles'];
+        public static $categoriesLink = ['link' => ''];
 
-    //$I->clickToolbarButton('rebuild'); didn't work
-    public static $rebuildButton = ['id' => 'toolbar-refresh'];
+        public static $archiveArticles = ['link' => 'Archived Articles'];
 
-    public static $trashButton = ['id' => 'toolbar-trash'];
+        public static $successMessage = 'Menu item saved';
 
-    public static $successMessage = 'Menu item saved';
+        public static $selectMenu = ['id' => 'menutype'];
 
-    public static $selectMenu = ['id' => 'menutype'];
+        public static $selectMainMenu = ['xpath' => '//select[@id="menutype"]/option[@value="mainmenu"]'];
 
-    public static $selectMainMenu = ['xpath' => '//select[@id="menutype"]/option[@value="mainmenu"]'];
+        public static $homeButton = ['id' => 'toolbar-default'];
 
-    public static $homeButton = ['id' => 'toolbar-default'];
+        public static $checkInButton = ['id' => 'toolbar-checkin'];
 
-    public static $checkInButton = ['id' => 'toolbar-checkin'];
+        public static $selectCategory = ['xpath' => '//*[@id="jform_request_catid"]/option[2]'];
+
+        /**
+        * Drop Down Toggle Element.
+        *
+        * @var    array
+        * @since  __DEPLOY_VERSION__
+        */
+        public static $dropDownToggle = ['xpath' => "//button[contains(@class, 'dropdown-toggle')]"];
+
+        /**
+         * Selecting category or article
+         *
+         * @var    array
+         * @since  __DEPLOY_VERSION__
+         */
+        public static $select = ['id' => 'jform_request_id_select'];
 
 }
 

--- a/src/_support/Page/Acceptance/Administrator/MenuItem.php
+++ b/src/_support/Page/Acceptance/Administrator/MenuItem.php
@@ -13,83 +13,90 @@
     class MenuItem
     {
         // include url of current page
-        public static $url = "administrator/index.php?option=com_menus&view=items";
+    public static $url = "administrator/index.php?option=com_menus&view=items";
 
         /**
          * New User Button
          *
-         * @var    string
-         * @since  3.7.3
+         * @var   string
+         * @since 3.7.3
          */
-        public static $newButton = ['id' => 'toolbar-new'];
+    public static $newButton = ['id' => 'toolbar-new'];
 
         /**
          * Menu Item Title
          *
-         * @var    string
-         * @since  3.7.3
+         * @var   string
+         * @since 3.7.3
          */
-        public static $menuItemTitle = ['id' => 'jform_title'];
+    public static $menuItemTitle = ['id' => 'jform_title'];
 
         /**
          * Menu Item Alias
          *
-         * @var    string
-         * @since  3.7.3
+         * @var   string
+         * @since 3.7.3
          */
-        public static $menuItemAlias = ['id' => 'jform_alias'];
+    public static $menuItemAlias = ['id' => 'jform_alias'];
 
         /**
          * Menu Item Save
          *
-         * @var    string
-         * @since  3.7.3
+         * @var   string
+         * @since 3.7.3
          */
-        public static  $saveButton = ['id' => 'toolbar-apply'];
+    public static  $saveButton = ['id' => 'toolbar-apply'];
 
         /**
          * Page title of the user manager listing page.
          *
-         * @var    string
-         * @since  3.7.3
+         * @var   string
+         * @since 3.7.3
          */
-        public static $pageTitleText = "Menus";
+    public static $pageTitleText = "Menus";
 
 
         /**
-         * drop down menu
+         * A drop down menu
          *
-         * @var    string
-         * @since  3.7.3
+         * @var   string
+         * @since 3.7.3
          */
-        public static $menuDropDown = ['xpath' => '//select[@id="jform_menutype"]'];
+    public static $menuDropDown = ['xpath' => '//select[@id="jform_menutype"]'];
 
         /**
-         * selecting option from dropdown menu
+         * Selecting option from dropdown menu
          *
-         * @var    string
-         * @since  3.7.3
+         * @var   string
+         * @since 3.7.3
          */
-        public static $selectOption = ['xpath' => '//select[@id="jform_menutype"]/option[@value="mainmenu"]'];
+    public static $selectOption = ['xpath' => '//select[@id="jform_menutype"]/option[@value="mainmenu"]'];
 
         /**
-         * check on the checkbox status
-         *
-         * @var    string
-         * @since  __DEPLOY_VERSION__
-         */
-        public static $checkAll = ['class' => 'hasTooltip'];
+        * check on the checkbox status
+        *
+        * @var    string
+        * @since __DEPLOY_VERSION__
+        */
+    public static $check = ['id' => 'cb0'];
 
 
-        public static $menuTypeModal = ['id' => 'menuTypeModal'];
+    public static $menuTypeModal = ['id' => 'menuTypeModal'];
 
-        public static $articlesLink = ['link' => 'Articles'];
+    public static $articlesLink = ['link' => 'Articles'];
 
-        public static $archiveArticlesLink = ['link' => 'Archived Articles'];
+    public static $archiveArticles = ['link' => 'Archived Articles'];
 
-        //$I->clickToolbarButton('rebuild'); didn't work 
-        public static $rebuildButton = ['id' => 'toolbar-refresh'];
+    //$I->clickToolbarButton('rebuild'); didn't work
+    public static $rebuildButton = ['id' => 'toolbar-refresh'];
 
-        public static $successMessage = 'Menu item saved';
+    public static $trashButton = ['id' => 'toolbar-trash'];
+
+    public static $successMessage = 'Menu item saved';
+
+    public static $selectMenu = ['id' => 'menutype'];
+
+    public static $selectMainMenu = ['xpath' => '//select[@id="menutype"]/option[@value="mainmenu"]'];
+
     }
 

--- a/src/_support/Page/Acceptance/Administrator/MenuItem.php
+++ b/src/_support/Page/Acceptance/Administrator/MenuItem.php
@@ -1,0 +1,95 @@
+<?php
+
+    /**
+     * @package     Joomla.Test
+     * @subpackage  AcceptanceTester.Page
+     *
+     * @copyright   Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+     * @license     GNU General Public License version 2 or later; see LICENSE.txt
+     */
+
+    namespace Page\Acceptance\Administrator;
+
+    class MenuItem
+    {
+        // include url of current page
+        public static $url = "administrator/index.php?option=com_menus&view=items";
+
+        /**
+         * New User Button
+         *
+         * @var    string
+         * @since  3.7.3
+         */
+        public static $newButton = ['id' => 'toolbar-new'];
+
+        /**
+         * Menu Item Title
+         *
+         * @var    string
+         * @since  3.7.3
+         */
+        public static $menuItemTitle = ['id' => 'jform_title'];
+
+        /**
+         * Menu Item Alias
+         *
+         * @var    string
+         * @since  3.7.3
+         */
+        public static $menuItemAlias = ['id' => 'jform_alias'];
+
+        /**
+         * Menu Item Save
+         *
+         * @var    string
+         * @since  3.7.3
+         */
+        public static  $saveButton = ['id' => 'toolbar-apply'];
+
+        /**
+         * Page title of the user manager listing page.
+         *
+         * @var    string
+         * @since  3.7.3
+         */
+        public static $pageTitleText = "Menus";
+
+
+        /**
+         * drop down menu
+         *
+         * @var    string
+         * @since  3.7.3
+         */
+        public static $menuDropDown = ['xpath' => '//select[@id="jform_menutype"]'];
+
+        /**
+         * selecting option from dropdown menu
+         *
+         * @var    string
+         * @since  3.7.3
+         */
+        public static $selectOption = ['xpath' => '//select[@id="jform_menutype"]/option[@value="mainmenu"]'];
+
+        /**
+         * check on the checkbox status
+         *
+         * @var    string
+         * @since  __DEPLOY_VERSION__
+         */
+        public static $checkAll = ['class' => 'hasTooltip'];
+
+
+        public static $menuTypeModal = ['id' => 'menuTypeModal'];
+
+        public static $articlesLink = ['link' => 'Articles'];
+
+        public static $archiveArticlesLink = ['link' => 'Archived Articles'];
+
+        //$I->clickToolbarButton('rebuild'); didn't work 
+        public static $rebuildButton = ['id' => 'toolbar-refresh'];
+
+        public static $successMessage = 'Menu item saved';
+    }
+

--- a/src/_support/Page/Acceptance/Administrator/MenuItem.php
+++ b/src/_support/Page/Acceptance/Administrator/MenuItem.php
@@ -1,17 +1,26 @@
 <?php
 
     /**
-     * @package     Joomla.Test
+     * @package  Joomla.Test
      * @subpackage  AcceptanceTester.Page
      *
-     * @copyright   Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
-     * @license     GNU General Public License version 2 or later; see LICENSE.txt
+     * @copyright   Copyright (C) 20018 - 2019 Open Source Matters, Inc.All rights reserved.
+     * @license     GNU General Public License version 2 or later;see LICENSE.txt
+     *  7.0.30
      */
 
-    namespace Page\Acceptance\Administrator;
+namespace Page\Acceptance\Administrator;
 
-    class MenuItem
-    {
+    /**
+     * Acceptance Page object class to menu items page objects.
+     *
+     * @package Page\Acceptance\Administrator
+     *
+     * @since __DEPLOY_VERSION__
+     */
+
+class MenuItem
+{
         // include url of current page
     public static $url = "administrator/index.php?option=com_menus&view=items";
 
@@ -72,12 +81,12 @@
          */
     public static $selectOption = ['xpath' => '//select[@id="jform_menutype"]/option[@value="mainmenu"]'];
 
-        /**
-        * check on the checkbox status
-        *
-        * @var    string
-        * @since __DEPLOY_VERSION__
-        */
+          /**
+           * Select  the checkbox status
+           *
+           * @var   string
+           * @since __DEPLOY_VERSION__
+           */
     public static $check = ['id' => 'cb0'];
 
 
@@ -98,5 +107,9 @@
 
     public static $selectMainMenu = ['xpath' => '//select[@id="menutype"]/option[@value="mainmenu"]'];
 
-    }
+    public static $homeButton = ['id' => 'toolbar-default'];
+
+    public static $checkInButton = ['id' => 'toolbar-checkin'];
+
+}
 

--- a/src/_support/Page/Acceptance/Administrator/MenuManagerPage.php
+++ b/src/_support/Page/Acceptance/Administrator/MenuManagerPage.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @package     Joomla.Test
+ * @subpackage  AcceptanceTester.Page
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Page\Acceptance\Administrator;
+
+/**
+ * Acceptance Page object class to menu objects.
+ *
+ * @package  Page\Acceptance\Administrator
+ *
+ * @since    __DEPLOY_VERSION__
+ */
+class MenuManagerPage extends AdminPage
+{
+	/**
+	 * Url to menu page.
+	 *
+	 * @var    string
+	 * @since __DEPLOY_VERSION__
+	 */
+	public static $url = "administrator/index.php?option=com_menus&view=menus";
+
+	/**
+	 * Page title of the menu page.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $pageTitleText = 'Menus';
+
+    /**
+     * Select the second menu
+     * cb0 -> id of first option and cb1-> id of second option
+     *@var string
+     * @since  __DEPLOY_VERSION__
+	 * I will change the xpath later. This is for temporary basis
+     */
+	public static $menuSelect = ['id' => 'cb1'];
+
+
+}

--- a/src/_support/Step/Acceptance/Administrator/Content.php
+++ b/src/_support/Step/Acceptance/Administrator/Content.php
@@ -3,13 +3,13 @@
  * @package     Joomla.Test
  * @subpackage  AcceptanceTester.Step
  *
- * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 namespace Step\Acceptance\Administrator;
 
-use Page\Acceptance\Administrator\ContentListPage;
+use Page\Acceptance\Administrator\ArticleManagerPage;
 
 /**
  * Acceptance Step object class contains suits for Content Manager.
@@ -20,56 +20,66 @@ use Page\Acceptance\Administrator\ContentListPage;
  */
 class Content extends Admin
 {
-	/**
-	 * Helper function to create a new Article
-	 *
-	 * @param   string  $title
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
+
+	public function createArticle($title, $body, $category)
+	{
+		$I = $this;
+		$I->amOnPage(ArticleManagerPage::$url);
+		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
+		$I->clickToolbarButton('New');
+		$this->articleManagerPage->fillContentCreateForm($title, $body);
+        if($category!='null'){
+            $I->click(ArticleManagerPage::$selectCategory);
+            $I->fillField(ArticleManagerPage::$fillCategory,$category);
+        }
+		$I->click(ArticleManagerPage::$dropDownToggle);
+		$I->clickToolbarButton('Save & Close');
+		$I->articleManagerPage->seeItemIsCreated($title);
+	}
+
 	public function featureArticle($title)
 	{
 		$I = $this;
-		$I->amOnPage(ContentListPage::$url);
-		$I->waitForElement(ContentListPage::$filterSearch, TIMEOUT);
+		$I->amOnPage(ArticleManagerPage::$url);
+		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
 		$I->searchForItem($title);
 		$I->checkAllResults();
 		$I->clickToolbarButton('feature');
-		$I->seeNumberOfElements(ContentListPage::$seeFeatured, 1);
+		$I->seeNumberOfElements(ArticleManagerPage::$seeFeatured, 1);
 	}
 
 	public function setArticleAccessLevel($title, $accessLevel)
 	{
 		$I = $this;
-		$I->amOnPage(ContentListPage::$url);
-		$I->waitForElement(ContentListPage::$filterSearch, TIMEOUT);
+		$I->amOnPage(ArticleManagerPage::$url);
+		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
 		$I->searchForItem($title);
 		$I->checkAllResults();
 		$I->click($title);
 		$I->waitForElement(['id' => "jform_access"], TIMEOUT);
 		$I->selectOption(['id' => "jform_access"], $accessLevel);
-		$I->click(ContentListPage::$dropDownToggle);
+		$I->click(ArticleManagerPage::$dropDownToggle);
 		$I->clickToolbarButton('Save & Close');
-		$I->waitForElement(ContentListPage::$filterSearch, TIMEOUT);
-		$I->see($accessLevel, ContentListPage::$seeAccessLevel);
+		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
+		$I->see($accessLevel, ArticleManagerPage::$seeAccessLevel);
 	}
 
 	public function unPublishArticle($title)
 	{
 		$I = $this;
-		$I->amOnPage(ContentListPage::$url);
-		$I->waitForElement(ContentListPage::$filterSearch, TIMEOUT);
+		$I->amOnPage(ArticleManagerPage::$url);
+		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
 		$I->searchForItem($title);
 		$I->checkAllResults();
 		$I->clickToolbarButton('unpublish');
-		$I->seeNumberOfElements(ContentListPage::$seeUnpublished, 1);
+		$I->seeNumberOfElements(ArticleManagerPage::$seeUnpublished, 1);
 	}
 
 	public function trashArticle($title)
 	{
 		$I = $this;
-		$I->amOnPage(ContentListPage::$url);
-		$I->waitForElement(ContentListPage::$filterSearch, TIMEOUT);
+		$I->amOnPage(ArticleManagerPage::$url);
+		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
 		$this->articleManagerPage->haveItemUsingSearch($title);
 		$I->clickToolbarButton('trash');
 		$I->searchForItem($title);

--- a/src/_support/Step/Acceptance/Administrator/Content.php
+++ b/src/_support/Step/Acceptance/Administrator/Content.php
@@ -28,10 +28,11 @@ class Content extends Admin
 		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
 		$I->clickToolbarButton('New');
 		$this->articleManagerPage->fillContentCreateForm($title, $body);
-        if($category!='null'){
-            $I->click(ArticleManagerPage::$selectCategory);
-            $I->fillField(ArticleManagerPage::$fillCategory,$category);
-        }
+        	if($category!='null'){
+            		$I->click(ArticleManagerPage::$selectCategory);
+            		$I->fillField(ArticleManagerPage::$fillCategory,$category);
+			 $I->pressKey(ArticleManagerPage::$fillCategory,\Facebook\WebDriver\WebDriverKeys::ENTER);
+       		}
 		$I->click(ArticleManagerPage::$dropDownToggle);
 		$I->clickToolbarButton('Save & Close');
 		$I->articleManagerPage->seeItemIsCreated($title);

--- a/src/_support/Step/Acceptance/Administrator/Content.php
+++ b/src/_support/Step/Acceptance/Administrator/Content.php
@@ -31,7 +31,7 @@ class Content extends Admin
         	if($category!='null'){
             		$I->click(ArticleManagerPage::$selectCategory);
             		$I->fillField(ArticleManagerPage::$fillCategory,$category);
-			 $I->pressKey(ArticleManagerPage::$fillCategory,\Facebook\WebDriver\WebDriverKeys::ENTER);
+			$I->pressKey(ArticleManagerPage::$fillCategory,\Facebook\WebDriver\WebDriverKeys::ENTER);
        		}
 		$I->click(ArticleManagerPage::$dropDownToggle);
 		$I->clickToolbarButton('Save & Close');

--- a/src/acceptance/administrator/components/com_category_menu/CategoryMenuCest.php
+++ b/src/acceptance/administrator/components/com_category_menu/CategoryMenuCest.php
@@ -1,0 +1,119 @@
+<?php
+    /**
+     * @package     Joomla.Tests
+     * @subpackage  Acceptance.tests
+     *
+     * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+     * @license     GNU General Public License version 2 or later; see LICENSE.txt
+     */
+    namespace administrator\components\com_category_menu;
+    use Step\Acceptance\Administrator\Admin;
+    use Step\Acceptance\Administrator\Category as CategoryStep;
+    use Step\Acceptance\Administrator\Content as ContentStep;
+    use Page\Acceptance\Administrator;
+    use Faker\Factory as fakerLib;
+
+    class CategoryMenuCest
+    {
+        public function __construct()
+        {
+            $faker = fakerLib::create();
+
+            $this->categoryTitle = $faker->name;
+            $this->articleTitle = $faker->name;
+            $this->articleContent = $faker->text;
+            $this->menuItemName = $faker->name;
+            $this->menuItemAlias = $faker->name;
+        }
+
+        public function Category(\AcceptanceTester $I, $scenario)
+        {
+            $I = new CategoryStep($scenario);
+            $I->doAdministratorLogin();
+            $I->createContentCategory($this->categoryTitle);
+        }
+
+        public function createArticles(\AcceptanceTester $I, $scenario)
+        {
+            $I = new ContentStep($scenario);
+            for ($j=0;$j<2;$j++) {
+                $I->doAdministratorLogin();
+                $I->createArticle($this->articleTitle, $this->articleContent, $this->categoryTitle);
+            }
+        }
+
+        public function createMenuForCategory(\AcceptanceTester $I)
+        {
+            $I->comment('I am going to create a menu item');
+            $I->doAdministratorLogin();
+
+
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
+
+            $I->waitForText(Administrator\MenuItem::$pageTitleText);
+
+            /**
+             * Creating A New Menu item
+             *  1. click on "new" botton
+             *  2. fill the Menu Select type
+             *  3. fill two fields : menu item name and alias
+             *  4. click on "save" button
+             */
+
+            $I->click(['id' => "menu-collapse"]);
+
+            $I->clickToolbarButton('new');
+
+
+            $I->fillField(Administrator\MenuItem::$menuItemTitle, $this->menuItemName);
+            $I->fillField(Administrator\MenuItem::$menuItemAlias, $this->menuItemAlias);
+
+            $I->waitForText('Select');
+
+            $I->click('Select');
+            $I->checkForPhpNoticesOrWarnings();
+            $I->switchToIFrame();
+            $I->waitForElement(Administrator\MenuItem::$menuTypeModal, TIMEOUT);
+            $I->switchToIFrame("Menu Item Type");
+            $I->waitForElement(Administrator\MenuItem::$articlesLink, TIMEOUT);
+            $I->click(['link' => 'Articles']);
+
+            /**
+             * Options under Articles
+             * Archived Article
+             * Featured Article
+             * Create Article
+             * Category Blog
+             * Category List
+             * List All Categories
+             * Single Article  <- We chose this Option
+             */
+            $I->wait(.5);
+            $I->waitForElement( "//div[contains(text(), 'Category Blog')]", TIMEOUT);
+            $I->scrollTo("//div[contains(text(), 'Category Blog')]");
+            $I->click("//div[contains(text(), 'Category Blog')]");
+
+            //Select Category
+            $I->click(Administrator\MenuItem::$select);
+
+            //The below line of code is to select category
+            $I->click(['xpath' => '//a[contains(text(),\''.$this->categoryTitle.'\')]']);
+            
+            //Select option from dropdown menu
+            $I->waitForElement(Administrator\MenuItem::$menuDropDown);
+            $I->click(Administrator\MenuItem::$menuDropDown);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectOption);
+            $I->selectOption(Administrator\MenuItem::$menuDropDown, $option);
+
+            //Save the menu item
+            $I->click(Administrator\MenuItem::$dropDownToggle);
+            $I->clickToolbarButton('save & close');
+
+            // Success message
+            $I->see(Administrator\MenuItem::$successMessage, Administrator\AdminPage::$systemMessageContainer);
+
+            $I->searchForItem($this->menuItemName);
+
+        }
+    }

--- a/src/acceptance/administrator/components/com_content/ArticleCest.php
+++ b/src/acceptance/administrator/components/com_content/ArticleCest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @package     Joomla.Tests
+ * @subpackage  Acceptance.tests
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+use Step\Acceptance\Administrator\Content as ContentStep;
+use Page\Acceptance\Administrator\ArticleManagerPage;
+
+class ArticleCest
+{
+	public function __construct()
+	{
+		$this->articleTitle = 'Article title';
+		$this->articleContent = 'Article content';
+		$this->articleAccessLevel = "Registered";
+	}
+
+	public function _before(AcceptanceTester $I)
+	{
+		$I->doAdministratorLogin();
+	}
+
+	public function Article(AcceptanceTester $I, $scenario)
+	{
+		$I = new ContentStep($scenario);
+		$I->createArticle($this->articleTitle, $this->articleContent, 'null');
+		$I->featureArticle($this->articleTitle);
+		$I->setArticleAccessLevel($this->articleTitle, $this->articleAccessLevel);
+		$I->unPublishArticle($this->articleTitle);
+		$I->trashArticle($this->articleTitle);
+	}
+}

--- a/src/acceptance/administrator/components/com_menu/MenuCest.php
+++ b/src/acceptance/administrator/components/com_menu/MenuCest.php
@@ -7,10 +7,11 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-use Page\Acceptance\Administrator\MenuListPage;
-use Page\Acceptance\Administrator\MenuFormPage;
-use Page\Acceptance\Administrator\AdminPage;
 
+use Page\Acceptance\Administrator\MenuManagerPage as MenuPage;
+use Page\Acceptance\Administrator\MenuEditPage as EditPage;
+use Page\Acceptance\Administrator\AdminPage as AdminPage;
+use Page\Acceptance\Administrator\MenuItem as MenuItem;
 /**
  * Administrator Menu Tests
  *
@@ -21,32 +22,34 @@ class MenuCest
 	/**
 	 * Create a menu
 	 *
-	 * @param   AcceptanceTester  $I  The AcceptanceTester Object
+	 * @param AcceptanceTester $I The AcceptanceTester Object
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 *
 	 * @return  void
 	 */
-	public function createNewMenu(\AcceptanceTester $I)
-	{
-		$I->comment('I am going to create a menu');
-		$I->doAdministratorLogin();
+    public function createNewMenu(\AcceptanceTester $I)
+    {
+        $I->comment('I am going to create a menu');
+	    $I->doAdministratorLogin();
 
-		$I->amOnPage(MenuListPage::$url);
-		$I->checkForPhpNoticesOrWarnings();
+	    $I->amOnPage(MenuPage::$url);
+	    $I->checkForPhpNoticesOrWarnings();
 
-		$I->waitForText(MenuListPage::$pageTitleText);
-		$I->click(['id' => "menu-collapse"]);
+	    $I->waitForText(MenuPage::$pageTitleText);
 
-		$I->clickToolbarButton('new');
-		$I->waitForText(MenuFormPage::$pageTitleText);
-		$I->checkForPhpNoticesOrWarnings();
+	    $I->clickToolbarButton('new');
+	    $I->waitForText(EditPage::$pageTitleText);
+	    $I->checkForPhpNoticesOrWarnings();
 
-		$this->fillMenuInformation($I, 'Test Menu');
+	    $this->fillMenuInfo($I);
 
-		$I->clickToolbarButton('save');
-		$I->waitForText(MenuListPage::$pageTitleText);
-		$I->checkForPhpNoticesOrWarnings();
+    	$I->clickToolbarButton('save');
+	    $I->waitForText(MenuPage::$pageTitleText);
+	    $I->checkForPhpNoticesOrWarnings();
+
+        $I->see('Menu saved',AdminPage::$systemMessageContainer);
+		//
 	}
 
 
@@ -62,10 +65,42 @@ class MenuCest
 	 *
 	 * @return  void
 	 */
-	protected function fillMenuInformation($I, $title, $type = 'Test', $description = 'Automated Testing')
+
+	protected function fillMenuInfo($I)
 	{
-		$I->fillField(MenuFormPage::$fieldTitle, $title);
-		$I->fillField(MenuFormPage::$fieldMenuType, $type);
-		$I->fillField(MenuFormPage::$fieldMenuDescription, $description);
+		$I->fillField(EditPage::$fieldTitle,'MenuNumOne');
+		$I->fillField(EditPage::$fieldMenuType,'mn1');
+		$I->fillField(EditPage::$fieldMenuDescription, 'This is a test menu');
 	}
+
+
+   public function rebuildMenu(\AcceptanceTester $I){
+
+	   $I->comment('I am going to rebuild a menu');
+       $I->doAdministratorLogin();
+
+       $I->amOnPage(MenuPage::$url);
+       $I->checkForPhpNoticesOrWarnings();
+
+       $I->click(MenuPage::$menuSelect);
+
+       //$I->clickToolbarButton('rebuild');
+        $I->click(MenuItem::$rebuildButton);
+
+       $I->see('Successfully rebuilt',AdminPage::$systemMessageContainer);
+   }
+
+
+    public function deleteMenu(\AcceptanceTester $I){
+        $I->comment('I am going to delete a menu');
+        $I->doAdministratorLogin();
+
+        $I->amOnPage(MenuPage::$url);
+        $I->checkForPhpNoticesOrWarnings();
+
+        $I->click(MenuPage::$menuSelect);
+        $I->clickToolbarButton('delete');
+
+    }
+
 }

--- a/src/acceptance/administrator/components/com_menu/MenuItemCest.php
+++ b/src/acceptance/administrator/components/com_menu/MenuItemCest.php
@@ -8,60 +8,62 @@
      */
 
 namespace menuItemCest;
-    use Page\Acceptance\Administrator;
-    use Page\Acceptance\Administrator\MenuManagerPage as MenuPage;
+use Page\Acceptance\Administrator;
+
 
     /**
      * Administrator Menu Items Test
      *
-     * @since  3.7.3
+     * @since 3.7.3
      */
 
-    class MenuItemCest
-    {
+class MenuItemCest
+{
 
-        /**
-         * Create a menu item
-         *
-         * @param \AcceptanceTester $I The AcceptanceTester Object
-         *
-         * @since __DEPLOY_VERSION__
-         *
-         * @return void
-         */
+
+    /**
+     * Create Menu Item
+     *
+     * @param \AcceptanceTester $I
+     *
+     * @throws \Exception
+     *
+     * @since __DEPLOY_VERSION__
+     *
+     * @return void
+     */
     public function createMenuItem(\AcceptanceTester $I)
     {
-            /**
-             * Initializing values of variables
-             * using faker library
-             * string   menuItemName    name of menu item
-             * string   menuItemAlias   alias of menu item
-             */
+        /**
+         * Initializing values of variables
+         * using faker library
+         * string   menuItemName    name of menu item
+         * string   menuItemAlias   alias of menu item
+         */
 
         $menuItemName = 'Test Menu Item Number One';
         $menuItemAlias = 'TestMenuItemOne';
 
 
-            //Stating what is about to be done
+        //Stating what is about to be done
 
         $I->comment('I am going to create a menu item');
         $I->doAdministratorLogin();
 
-            //As per url specified in step file MenuItem
+        //As per url specified in step file MenuItem
 
         $I->amOnPage(Administrator\MenuItem::$url);
         $I->checkForPhpNoticesOrWarnings();
 
         $I->waitForText(Administrator\MenuItem::$pageTitleText);
 
-
-            /**
-             * Creating A New Menu item
-             *  1. click on "new" botton
-             *  2. fill the Menu Select type
-             *  3. fill two fields : menu item name and alias
-             *  4. click on "save" button
-             */
+        /**
+         * Creating A New Menu item
+         *  1. click on "new" botton
+         *  2. fill the Menu Select type
+         *  3. fill two fields : menu item name and alias
+         *  4. click on "save" button
+         */
 
         $I->click(['id' => "menu-collapse"]);
 
@@ -82,23 +84,22 @@ namespace menuItemCest;
         $I->fillField(Administrator\MenuItem::$menuItemAlias, $menuItemAlias);
 
 
-            /**
-             * Select option from dropdown menu
-            */
+
+        //Select option from dropdown menu
+
         $I->waitForElement(Administrator\MenuItem::$menuDropDown);
         $I->click(Administrator\MenuItem::$menuDropDown);
         $option = $I->grabTextFrom(Administrator\MenuItem::$selectOption);
         $I->selectOption(Administrator\MenuItem::$menuDropDown, $option);
 
 
-            /**
-             * Save the menu item
-             */
+
+        //Save the menu item
+
         $I->clickToolbarButton('save');
 
-            /**
-            * Success message
-            */
+
+        // Success message
         $I->see(Administrator\MenuItem::$successMessage, Administrator\AdminPage::$systemMessageContainer);
     }
 
@@ -131,7 +132,6 @@ namespace menuItemCest;
     }
 
 
-
         /**
          * Publish a menu
          *
@@ -161,6 +161,91 @@ namespace menuItemCest;
     }
 
         /**
+         * Check In A Menu Item
+         *
+         * @param \AcceptanceTester $I The AcceptanceTester Object
+         *
+         * @since __DEPLOY_VERSION__
+         *
+         * @return void
+         */
+    public function checkInMenuItems(\AcceptanceTester $I)
+    {
+
+        $I->comment('I am going to check in a menu item');
+        $I->doAdministratorLogin();
+
+        $I->amOnPage(Administrator\MenuItem::$url);
+        $I->checkForPhpNoticesOrWarnings();
+
+        $I->click(Administrator\MenuItem::$selectMenu);
+        $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+        $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+
+        $I->click(Administrator\MenuItem::$check);
+
+        $I->click(Administrator\MenuItem::$checkInButton);
+
+    }
+
+        /**
+         * Set A Menu Item To Home
+         *
+         * @param \AcceptanceTester $I The AcceptanceTester Object
+         *
+         * @since __DEPLOY_VERSION__
+         *
+         * @return void
+         */
+    public function setHomeMenuItems(\AcceptanceTester $I)
+    {
+
+        $I->comment('I am going to set a menu item to home');
+        $I->doAdministratorLogin();
+
+        $I->amOnPage(Administrator\MenuItem::$url);
+        $I->checkForPhpNoticesOrWarnings();
+
+        $I->click(Administrator\MenuItem::$selectMenu);
+        $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+        $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+
+        $I->click(Administrator\MenuItem::$check);
+
+        //Home button doesn't exist in JoomlaBrowser.php file (joomla-browser)
+        $I->click(Administrator\MenuItem::$homeButton);
+
+    }
+
+        /**
+         * Rebuild A Menu Item
+         *
+         * @param \AcceptanceTester $I The AcceptanceTester Object
+         *
+         * @since __DEPLOY_VERSION__
+         *
+         * @return void
+         */
+    public function rebuildMenuItems(\AcceptanceTester $I)
+    {
+
+        $I->comment('I am going to rebuild a menu item');
+        $I->doAdministratorLogin();
+
+        $I->amOnPage(Administrator\MenuItem::$url);
+        $I->checkForPhpNoticesOrWarnings();
+
+        $I->click(Administrator\MenuItem::$selectMenu);
+        $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+        $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+
+        $I->click(Administrator\MenuItem::$check);
+
+        $I->click(Administrator\MenuItem::$rebuildButton);
+
+    }
+
+        /**
          * Trash Menu Items
          *
          * @param \AcceptanceTester $I The AcceptanceTester Object
@@ -172,7 +257,7 @@ namespace menuItemCest;
     public function trashMenuItems(\AcceptanceTester $I)
     {
 
-        $I->comment('I am going to unpublish a menu');
+        $I->comment('I am going to trash a menu item');
         $I->doAdministratorLogin();
 
         $I->amOnPage(Administrator\MenuItem::$url);
@@ -188,5 +273,5 @@ namespace menuItemCest;
 
     }
 
-    }
+}
 

--- a/src/acceptance/administrator/components/com_menu/MenuItemCest.php
+++ b/src/acceptance/administrator/components/com_menu/MenuItemCest.php
@@ -1,0 +1,192 @@
+<?php
+    /**
+     * @package     Joomla.Tests
+     * @subpackage  Acceptance.tests
+     *
+     * @copyright   Copyright (C) 20005 - 2019 Open Source Matters, Inc. All rights reserved.
+     * @license     GNU General Public License version 2 or later; see LICENSE.txt
+     */
+
+namespace menuItemCest;
+    use Page\Acceptance\Administrator;
+    use Page\Acceptance\Administrator\MenuManagerPage as MenuPage;
+
+    /**
+     * Administrator Menu Items Test
+     *
+     * @since  3.7.3
+     */
+
+    class MenuItemCest
+    {
+
+        /**
+         * Create a menu item
+         *
+         * @param \AcceptanceTester $I The AcceptanceTester Object
+         *
+         * @since __DEPLOY_VERSION__
+         *
+         * @return void
+         */
+    public function createMenuItem(\AcceptanceTester $I)
+    {
+            /**
+             * Initializing values of variables
+             * using faker library
+             * string   menuItemName    name of menu item
+             * string   menuItemAlias   alias of menu item
+             */
+
+        $menuItemName = 'Test Menu Item Number One';
+        $menuItemAlias = 'TestMenuItemOne';
+
+
+            //Stating what is about to be done
+
+        $I->comment('I am going to create a menu item');
+        $I->doAdministratorLogin();
+
+            //As per url specified in step file MenuItem
+
+        $I->amOnPage(Administrator\MenuItem::$url);
+        $I->checkForPhpNoticesOrWarnings();
+
+        $I->waitForText(Administrator\MenuItem::$pageTitleText);
+
+
+            /**
+             * Creating A New Menu item
+             *  1. click on "new" botton
+             *  2. fill the Menu Select type
+             *  3. fill two fields : menu item name and alias
+             *  4. click on "save" button
+             */
+
+        $I->click(['id' => "menu-collapse"]);
+
+        $I->clickToolbarButton('new');
+
+        $I->waitForText('Select');
+
+        $I->click('Select');
+        $I->checkForPhpNoticesOrWarnings();
+        $I->switchToIFrame();
+        $I->waitForElement(Administrator\MenuItem::$menuTypeModal, TIMEOUT);
+        $I->switchToIFrame("Menu Item Type");
+        $I->waitForElement(Administrator\MenuItem::$articlesLink, TIMEOUT);
+        $I->click(['link' => 'Articles']);
+        $I->click(['link' => 'Archived Articles']);
+
+        $I->fillField(Administrator\MenuItem::$menuItemTitle, $menuItemName);
+        $I->fillField(Administrator\MenuItem::$menuItemAlias, $menuItemAlias);
+
+
+            /**
+             * Select option from dropdown menu
+            */
+        $I->waitForElement(Administrator\MenuItem::$menuDropDown);
+        $I->click(Administrator\MenuItem::$menuDropDown);
+        $option = $I->grabTextFrom(Administrator\MenuItem::$selectOption);
+        $I->selectOption(Administrator\MenuItem::$menuDropDown, $option);
+
+
+            /**
+             * Save the menu item
+             */
+        $I->clickToolbarButton('save');
+
+            /**
+            * Success message
+            */
+        $I->see(Administrator\MenuItem::$successMessage, Administrator\AdminPage::$systemMessageContainer);
+    }
+
+        /**
+         * Unpublish a menu
+         *
+         * @param \AcceptanceTester $I The AcceptanceTester Object
+         *
+         * @since __DEPLOY_VERSION__
+         *
+         * @return void
+         */
+    public function unpublishMenuItems(\AcceptanceTester $I)
+    {
+
+        $I->comment('I am going to unpublish a menu');
+        $I->doAdministratorLogin();
+
+        $I->amOnPage(Administrator\MenuItem::$url);
+        $I->checkForPhpNoticesOrWarnings();
+
+        $I->click(Administrator\MenuItem::$selectMenu);
+        $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+        $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+
+        $I->click(Administrator\MenuItem::$check);
+
+        $I->clickToolbarButton('unpublish');
+
+    }
+
+
+
+        /**
+         * Publish a menu
+         *
+         * @param \AcceptanceTester $I The AcceptanceTester Object
+         *
+         * @since __DEPLOY_VERSION__
+         *
+         * @return void
+         */
+    public function publishMenuItems(\AcceptanceTester $I)
+    {
+
+        $I->comment('I am going to publish a menu');
+        $I->doAdministratorLogin();
+
+        $I->amOnPage(Administrator\MenuItem::$url);
+        $I->checkForPhpNoticesOrWarnings();
+
+        $I->click(Administrator\MenuItem::$selectMenu);
+        $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+        $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+
+        $I->click(Administrator\MenuItem::$check);
+
+        $I->clickToolbarButton('publish');
+
+    }
+
+        /**
+         * Trash Menu Items
+         *
+         * @param \AcceptanceTester $I The AcceptanceTester Object
+         *
+         * @since __DEPLOY_VERSION__
+         *
+         * @return void
+         */
+    public function trashMenuItems(\AcceptanceTester $I)
+    {
+
+        $I->comment('I am going to unpublish a menu');
+        $I->doAdministratorLogin();
+
+        $I->amOnPage(Administrator\MenuItem::$url);
+        $I->checkForPhpNoticesOrWarnings();
+
+        $I->click(Administrator\MenuItem::$selectMenu);
+        $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+        $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+
+        $I->click(Administrator\MenuItem::$check);
+
+        $I->click(Administrator\MenuItem::$trashButton);
+
+    }
+
+    }
+

--- a/src/acceptance/administrator/components/com_menu/MenuItemCest.php
+++ b/src/acceptance/administrator/components/com_menu/MenuItemCest.php
@@ -3,12 +3,12 @@
      * @package     Joomla.Tests
      * @subpackage  Acceptance.tests
      *
-     * @copyright   Copyright (C) 20005 - 2019 Open Source Matters, Inc. All rights reserved.
+     * @copyright   Copyright (C) 2018 - 2019 Open Source Matters, Inc. All rights reserved.
      * @license     GNU General Public License version 2 or later; see LICENSE.txt
      */
 
-namespace menuItemCest;
-use Page\Acceptance\Administrator;
+    namespace menuItemCest;
+    use Page\Acceptance\Administrator;
 
 
     /**
@@ -17,91 +17,82 @@ use Page\Acceptance\Administrator;
      * @since 3.7.3
      */
 
-class MenuItemCest
-{
-
-
-    /**
-     * Create Menu Item
-     *
-     * @param \AcceptanceTester $I
-     *
-     * @throws \Exception
-     *
-     * @since __DEPLOY_VERSION__
-     *
-     * @return void
-     */
-    public function createMenuItem(\AcceptanceTester $I)
+    class MenuItemCest
     {
-        /**
-         * Initializing values of variables
-         * using faker library
-         * string   menuItemName    name of menu item
-         * string   menuItemAlias   alias of menu item
-         */
-
-        $menuItemName = 'Test Menu Item Number One';
-        $menuItemAlias = 'TestMenuItemOne';
-
-
-        //Stating what is about to be done
-
-        $I->comment('I am going to create a menu item');
-        $I->doAdministratorLogin();
-
-        //As per url specified in step file MenuItem
-
-        $I->amOnPage(Administrator\MenuItem::$url);
-        $I->checkForPhpNoticesOrWarnings();
-
-        $I->waitForText(Administrator\MenuItem::$pageTitleText);
 
         /**
-         * Creating A New Menu item
-         *  1. click on "new" botton
-         *  2. fill the Menu Select type
-         *  3. fill two fields : menu item name and alias
-         *  4. click on "save" button
+         * Creates a menu item with the Joomla menu manager
+         *
+         * @param \AcceptanceTester $I
+         *
+         * @throws \Exception
+         * @since  3.0.0
+         * @return void
          */
+        public function menuItem(\AcceptanceTester $I)
+        {
 
-        $I->click(['id' => "menu-collapse"]);
+            /**
+             * Initializing values of variables
+             * using faker library
+             * string   menuItemName    name of menu item
+             * string   menuItemAlias   alias of menu item
+             */
+            $menuItemName = 'Menu Item 101 ';
+            $menuItemAlias = 'MenuItem101';
 
-        $I->clickToolbarButton('new');
+            $I->comment('I am going to create a menu item');
+            $I->doAdministratorLogin();
 
-        $I->waitForText('Select');
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
 
-        $I->click('Select');
-        $I->checkForPhpNoticesOrWarnings();
-        $I->switchToIFrame();
-        $I->waitForElement(Administrator\MenuItem::$menuTypeModal, TIMEOUT);
-        $I->switchToIFrame("Menu Item Type");
-        $I->waitForElement(Administrator\MenuItem::$articlesLink, TIMEOUT);
-        $I->click(['link' => 'Articles']);
-        $I->click(['link' => 'Archived Articles']);
+            $I->waitForText(Administrator\MenuItem::$pageTitleText);
 
-        $I->fillField(Administrator\MenuItem::$menuItemTitle, $menuItemName);
-        $I->fillField(Administrator\MenuItem::$menuItemAlias, $menuItemAlias);
+            /**
+             * Creating A New Menu item
+             *  1. click on "new" botton
+             *  2. fill the Menu Select type
+             *  3. fill two fields : menu item name and alias
+             *  4. click on "save" button
+             */
 
+            $I->click(['id' => "menu-collapse"]);
 
+            $I->clickToolbarButton('new');
 
-        //Select option from dropdown menu
+            $I->waitForText('Select');
 
-        $I->waitForElement(Administrator\MenuItem::$menuDropDown);
-        $I->click(Administrator\MenuItem::$menuDropDown);
-        $option = $I->grabTextFrom(Administrator\MenuItem::$selectOption);
-        $I->selectOption(Administrator\MenuItem::$menuDropDown, $option);
+            $I->click('Select');
+            $I->checkForPhpNoticesOrWarnings();
+            $I->switchToIFrame();
+            $I->waitForElement(Administrator\MenuItem::$menuTypeModal, TIMEOUT);
+            $I->switchToIFrame("Menu Item Type");
+            $I->waitForElement(Administrator\MenuItem::$articlesLink, TIMEOUT);
+            $I->click(['link' => 'Articles']);
+            $I->click(['link' => 'Archived Articles']);
 
+            $I->click(Administrator\MenuItem::$selectCategory);
 
+            $I->fillField(Administrator\MenuItem::$menuItemTitle, $menuItemName);
+            $I->fillField(Administrator\MenuItem::$menuItemAlias, $menuItemAlias);
 
-        //Save the menu item
+            //Select option from dropdown menu
+            $I->waitForElement(Administrator\MenuItem::$menuDropDown);
+            $I->click(Administrator\MenuItem::$menuDropDown);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectOption);
+            $I->selectOption(Administrator\MenuItem::$menuDropDown, $option);
 
-        $I->clickToolbarButton('save');
+            //Save the menu item
+            $I->click(Administrator\MenuItem::$dropDownToggle);
+            $I->clickToolbarButton('save & close');
 
+            // Success message
+            $I->see(Administrator\MenuItem::$successMessage, Administrator\AdminPage::$systemMessageContainer);
 
-        // Success message
-        $I->see(Administrator\MenuItem::$successMessage, Administrator\AdminPage::$systemMessageContainer);
-    }
+            $I->searchForItem($menuItemName);
+
+        }
 
         /**
          * Unpublish a menu
@@ -112,24 +103,24 @@ class MenuItemCest
          *
          * @return void
          */
-    public function unpublishMenuItems(\AcceptanceTester $I)
-    {
+        public function unpublishMenuItems(\AcceptanceTester $I)
+        {
 
-        $I->comment('I am going to unpublish a menu');
-        $I->doAdministratorLogin();
+            $I->comment('I am going to unpublish a menu');
+            $I->doAdministratorLogin();
 
-        $I->amOnPage(Administrator\MenuItem::$url);
-        $I->checkForPhpNoticesOrWarnings();
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
 
-        $I->click(Administrator\MenuItem::$selectMenu);
-        $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
-        $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+            $I->click(Administrator\MenuItem::$selectMenu);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+            $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
 
-        $I->click(Administrator\MenuItem::$check);
+            $I->click(Administrator\MenuItem::$check);
 
-        $I->clickToolbarButton('unpublish');
+            $I->clickToolbarButton('unpublish');
 
-    }
+        }
 
 
         /**
@@ -141,24 +132,24 @@ class MenuItemCest
          *
          * @return void
          */
-    public function publishMenuItems(\AcceptanceTester $I)
-    {
+        public function publishMenuItems(\AcceptanceTester $I)
+        {
 
-        $I->comment('I am going to publish a menu');
-        $I->doAdministratorLogin();
+            $I->comment('I am going to publish a menu');
+            $I->doAdministratorLogin();
 
-        $I->amOnPage(Administrator\MenuItem::$url);
-        $I->checkForPhpNoticesOrWarnings();
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
 
-        $I->click(Administrator\MenuItem::$selectMenu);
-        $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
-        $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+            $I->click(Administrator\MenuItem::$selectMenu);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+            $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
 
-        $I->click(Administrator\MenuItem::$check);
+            $I->click(Administrator\MenuItem::$check);
 
-        $I->clickToolbarButton('publish');
+            $I->clickToolbarButton('publish');
 
-    }
+        }
 
         /**
          * Check In A Menu Item
@@ -169,24 +160,24 @@ class MenuItemCest
          *
          * @return void
          */
-    public function checkInMenuItems(\AcceptanceTester $I)
-    {
+        public function checkInMenuItems(\AcceptanceTester $I)
+        {
 
-        $I->comment('I am going to check in a menu item');
-        $I->doAdministratorLogin();
+            $I->comment('I am going to check in a menu item');
+            $I->doAdministratorLogin();
 
-        $I->amOnPage(Administrator\MenuItem::$url);
-        $I->checkForPhpNoticesOrWarnings();
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
 
-        $I->click(Administrator\MenuItem::$selectMenu);
-        $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
-        $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+            $I->click(Administrator\MenuItem::$selectMenu);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+            $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
 
-        $I->click(Administrator\MenuItem::$check);
+            $I->click(Administrator\MenuItem::$check);
 
-        $I->click(Administrator\MenuItem::$checkInButton);
+            $I->click(Administrator\MenuItem::$checkInButton);
 
-    }
+        }
 
         /**
          * Set A Menu Item To Home
@@ -197,25 +188,25 @@ class MenuItemCest
          *
          * @return void
          */
-    public function setHomeMenuItems(\AcceptanceTester $I)
-    {
+        public function setHomeMenuItems(\AcceptanceTester $I)
+        {
 
-        $I->comment('I am going to set a menu item to home');
-        $I->doAdministratorLogin();
+            $I->comment('I am going to set a menu item to home');
+            $I->doAdministratorLogin();
 
-        $I->amOnPage(Administrator\MenuItem::$url);
-        $I->checkForPhpNoticesOrWarnings();
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
 
-        $I->click(Administrator\MenuItem::$selectMenu);
-        $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
-        $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+            $I->click(Administrator\MenuItem::$selectMenu);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+            $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
 
-        $I->click(Administrator\MenuItem::$check);
+            $I->click(Administrator\MenuItem::$check);
 
-        //Home button doesn't exist in JoomlaBrowser.php file (joomla-browser)
-        $I->click(Administrator\MenuItem::$homeButton);
+            //Home button doesn't exist in JoomlaBrowser.php file (joomla-browser)
+            $I->click(Administrator\MenuItem::$homeButton);
 
-    }
+        }
 
         /**
          * Rebuild A Menu Item
@@ -226,24 +217,24 @@ class MenuItemCest
          *
          * @return void
          */
-    public function rebuildMenuItems(\AcceptanceTester $I)
-    {
+        public function rebuildMenuItems(\AcceptanceTester $I)
+        {
 
-        $I->comment('I am going to rebuild a menu item');
-        $I->doAdministratorLogin();
+            $I->comment('I am going to rebuild a menu item');
+            $I->doAdministratorLogin();
 
-        $I->amOnPage(Administrator\MenuItem::$url);
-        $I->checkForPhpNoticesOrWarnings();
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
 
-        $I->click(Administrator\MenuItem::$selectMenu);
-        $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
-        $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+            $I->click(Administrator\MenuItem::$selectMenu);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+            $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
 
-        $I->click(Administrator\MenuItem::$check);
+            $I->click(Administrator\MenuItem::$check);
 
-        $I->click(Administrator\MenuItem::$rebuildButton);
+            $I->clickToolbarButton('rebuild');
 
-    }
+        }
 
         /**
          * Trash Menu Items
@@ -254,24 +245,23 @@ class MenuItemCest
          *
          * @return void
          */
-    public function trashMenuItems(\AcceptanceTester $I)
-    {
+        public function trashMenuItems(\AcceptanceTester $I)
+        {
 
-        $I->comment('I am going to trash a menu item');
-        $I->doAdministratorLogin();
+            $I->comment('I am going to trash a menu item');
+            $I->doAdministratorLogin();
 
-        $I->amOnPage(Administrator\MenuItem::$url);
-        $I->checkForPhpNoticesOrWarnings();
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
 
-        $I->click(Administrator\MenuItem::$selectMenu);
-        $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
-        $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+            $I->click(Administrator\MenuItem::$selectMenu);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+            $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
 
-        $I->click(Administrator\MenuItem::$check);
+            $I->click(Administrator\MenuItem::$check);
 
-        $I->click(Administrator\MenuItem::$trashButton);
+            $I->clickToolbarButton('trash');
+
+        }
 
     }
-
-}
-

--- a/src/acceptance/administrator/components/com_menu_article/ArticleMenuCest.php
+++ b/src/acceptance/administrator/components/com_menu_article/ArticleMenuCest.php
@@ -1,0 +1,143 @@
+<?php
+    /**
+     * @package     Joomla.Tests
+     * @subpackage  Acceptance.tests
+     *
+     * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+     * @license     GNU General Public License version 2 or later; see LICENSE.txt
+     */
+
+    namespace administrator\components\com_menu_article;
+    use Step\Acceptance\Administrator\Content as ContentStep;
+    use Page\Acceptance\Administrator;
+    use Faker\Factory as fakerLib;
+
+
+
+    /**
+     * Class ArticleMenuCest
+     *
+     * @category  Menu_Article
+     * @package   Administratorcomponentscom_Menu_Article
+     * @author    Samarth<samarthsharma351@gmail.com>
+     * @copyright 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+     * @license   Joomla 2005-2018
+     * @link      ArticleMenuCest
+     */
+    class ArticleMenuCest
+    {
+
+        public function __construct()
+        {
+            $faker = fakerLib::create();
+            $this->articleTitle = $faker->name;
+            $this->articleContent = $faker->text;
+            $this->menuItemName = $faker->name;
+            $this->menuItemAlias = $faker->userName;
+        }
+
+
+        /**
+         * Article is created
+         *
+         * @param \AcceptanceTester $I
+         * @param string            $scenario Scenario
+         *
+         * @return void
+         */
+        public function Article(\AcceptanceTester $I, $scenario)
+        {
+
+            $I = new ContentStep($scenario);
+            $I->doAdministratorLogin();
+            $I->createArticle($this->articleTitle, $this->articleContent, 'null');
+
+        }
+
+        /**
+         * Create Menu For Article
+         *
+         * @param \AcceptanceTester $I
+         *
+         * @return void
+         */
+        public function createMenuForArticle(\AcceptanceTester $I)
+        {
+            $I->comment('I am going to create a menu item');
+            $I->doAdministratorLogin();
+
+
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
+
+            $I->waitForText(Administrator\MenuItem::$pageTitleText);
+
+            /**
+             * Creating A New Menu item
+             *  1. click on "new" botton
+             *  2. fill the Menu Select type
+             *  3. fill two fields : menu item name and alias
+             *  4. click on "save" button
+             */
+
+            $I->click(['id' => "menu-collapse"]);
+
+            $I->clickToolbarButton('new');
+
+            $I->fillField(Administrator\MenuItem::$menuItemTitle, $this->menuItemName);
+            $I->fillField(Administrator\MenuItem::$menuItemAlias, $this->menuItemAlias);
+
+
+            $I->waitForText('Select');
+
+            $I->click('Select');
+            $I->checkForPhpNoticesOrWarnings();
+            $I->switchToIFrame();
+            $I->waitForElement(Administrator\MenuItem::$menuTypeModal, TIMEOUT);
+            $I->switchToIFrame("Menu Item Type");
+            $I->waitForElement(Administrator\MenuItem::$articlesLink, TIMEOUT);
+            $I->click(['link' => 'Articles']);
+
+            /**
+             * Options under Articles
+             * Archived Article
+             * Featured Article
+             * Create Article
+             * Category Blog
+             * Category List
+             * List All Categories
+             * Single Article  <- We chose this Option
+             */
+            $I->wait(.5);
+            $I->waitForElement( "//div[contains(text(), 'Single Article')]", TIMEOUT);
+            $I->scrollTo("//div[contains(text(), 'Single Article')]");
+            $I->click("//div[contains(text(), 'Single Article')]");
+
+
+            $I->click(Administrator\MenuItem::$select);
+           
+            $I->switchToIFrame('Select or Change article');
+            
+            //Search for item
+            $I->makeScreenshot();
+            // The below line of code is to select Article
+            $I->click(['xpath' => '//a[contains(text(),\''.$this->articleTitle.'\')]']);
+
+            //Select option from dropdown menu
+            $I->wait(1);
+            $I->click(Administrator\MenuItem::$menuDropDown);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectOption);
+            $I->selectOption(Administrator\MenuItem::$menuDropDown, $option);
+
+            //Save the menu item
+            $I->click(Administrator\MenuItem::$dropDownToggle);
+            $I->clickToolbarButton('save & close');
+
+            // Success message
+            $I->see(Administrator\MenuItem::$successMessage, Administrator\AdminPage::$systemMessageContainer);
+
+            $I->searchForItem($this->menuItemName);
+
+        }
+
+    }


### PR DESCRIPTION
@yvesh Can you please check the indentation one last time because my PHPStorm is configured to Joomla coding standards and its not showing any warning regarding indentation but it is showing warning regarding line exceeding 85 chararcters, variable not following regex(regular expression [A-Za-z])  although the name of var is simple as menuItemName.

@puneet0191 any suggestions? I will add the Article and menu tests by evening.
![selection_040](https://user-images.githubusercontent.com/19748816/40533850-a4c89f50-6021-11e8-8ab1-9c70c2acf65b.png)
![selection_041](https://user-images.githubusercontent.com/19748816/40533851-a54ab896-6021-11e8-9d67-c62975b2c5af.png)

The indentation is not changing when I am making a commit. It is same as last file

