### PR TITLE
Category menuitems

### DIFF
--- a/src/_support/Page/Acceptance/Administrator/MenuItem.php
+++ b/src/_support/Page/Acceptance/Administrator/MenuItem.php
@@ -89,25 +89,84 @@
         */
         public static $check = ['id' => 'cb0'];
 
-
+        /**
+         * Select Menu Type Modal
+         *
+         * @var    array
+         * @since  __DEPLOY_VERSION__
+         */
         public static $menuTypeModal = ['id' => 'menuTypeModal'];
 
+        /**
+         * Select Article Link
+         *
+         * @var    array
+         * @since  __DEPLOY_VERSION__
+         */
         public static $articlesLink = ['link' => 'Articles'];
 
+        /**
+         * Select Category Link
+         *
+         * @var    array
+         * @since  __DEPLOY_VERSION__
+         */
         public static $categoriesLink = ['link' => ''];
 
+        /**
+         * Archive Articles
+         *
+         * @var    array
+         * @since  __DEPLOY_VERSION__
+         */
         public static $archiveArticles = ['link' => 'Archived Articles'];
 
+        /**
+         * Success Message
+         *
+         * @var    string
+         * @since  __DEPLOY_VERSION__
+         */
         public static $successMessage = 'Menu item saved';
 
+        /**
+         * Select Menu
+         *
+         * @var    array
+         * @since  __DEPLOY_VERSION__
+         */
         public static $selectMenu = ['id' => 'menutype'];
 
+        /**
+         * Select Menu Menu
+         *
+         * @var    array
+         * @since  __DEPLOY_VERSION__
+         */
         public static $selectMainMenu = ['xpath' => '//select[@id="menutype"]/option[@value="mainmenu"]'];
 
+        /**
+         * Select Home Button
+         *
+         * @var    array
+         * @since  __DEPLOY_VERSION__
+         */
         public static $homeButton = ['id' => 'toolbar-default'];
 
+        /**
+         * Select Check in
+         *
+         * @var    array
+         * @since  __DEPLOY_VERSION__
+         */
         public static $checkInButton = ['id' => 'toolbar-checkin'];
 
+        /**
+         * Select category
+         *
+         * @var    array
+         * @since  __DEPLOY_VERSION__
+         */
         public static $selectCategory = ['xpath' => '//*[@id="jform_request_catid"]/option[2]'];
 
         /**
@@ -126,6 +185,12 @@
          */
         public static $select = ['id' => 'jform_request_id_select'];
 
+        /**
+         * Select Menu Type
+         *
+         * @var    array
+         * @since  __DEPLOY_VERSION__
+         */
         public static $selectMenuType = ['xpath' => '//select[@id=\'jform_request_id\']'];
 
 }

--- a/src/_support/Page/Acceptance/Administrator/MenuItem.php
+++ b/src/_support/Page/Acceptance/Administrator/MenuItem.php
@@ -1,0 +1,132 @@
+<?php
+
+    /**
+     * @package  Joomla.Test
+     * @subpackage  AcceptanceTester.Page
+     *
+     * @copyright   Copyright (C) 20018 - 2019 Open Source Matters, Inc.All rights reserved.
+     * @license     GNU General Public License version 2 or later;see LICENSE.txt
+     *  7.0.30
+     */
+
+    namespace Page\Acceptance\Administrator;
+
+    /**
+     * Acceptance Page object class to menu items page objects.
+     *
+     * @package Page\Acceptance\Administrator
+     *
+     * @since __DEPLOY_VERSION__
+     */
+
+    class MenuItem
+    {
+        // include url of current page
+        public static $url = "administrator/index.php?option=com_menus&view=items";
+
+        /**
+         * New User Button
+         *
+         * @var   string
+         * @since 3.7.3
+         */
+        public static $newButton = ['id' => 'toolbar-new'];
+
+        /**
+         * Menu Item Title
+         *
+         * @var   string
+         * @since 3.7.3
+         */
+        public static $menuItemTitle = ['id' => 'jform_title'];
+
+        /**
+         * Menu Item Alias
+         *
+         * @var   string
+         * @since 3.7.3
+         */
+        public static $menuItemAlias = ['id' => 'jform_alias'];
+
+        /**
+         * Menu Item Save
+         *
+         * @var   string
+         * @since 3.7.3
+         */
+        public static  $saveButton = ['id' => 'toolbar-apply'];
+
+        /**
+         * Page title of the user manager listing page.
+         *
+         * @var   string
+         * @since 3.7.3
+         */
+        public static $pageTitleText = "Menus";
+
+
+        /**
+         * A drop down menu
+         *
+         * @var   string
+         * @since 3.7.3
+         */
+        public static $menuDropDown = ['xpath' => '//select[@id="jform_menutype"]'];
+
+        /**
+         * Selecting option from dropdown menu
+         *
+         * @var   string
+         * @since 3.7.3
+         */
+        public static $selectOption = ['xpath' => '//select[@id="jform_menutype"]/option[@value="mainmenu"]'];
+
+       /**
+        * Select  the checkbox status
+        *
+        * @var   string
+        * @since __DEPLOY_VERSION__
+        */
+        public static $check = ['id' => 'cb0'];
+
+
+        public static $menuTypeModal = ['id' => 'menuTypeModal'];
+
+        public static $articlesLink = ['link' => 'Articles'];
+
+        public static $categoriesLink = ['link' => ''];
+
+        public static $archiveArticles = ['link' => 'Archived Articles'];
+
+        public static $successMessage = 'Menu item saved';
+
+        public static $selectMenu = ['id' => 'menutype'];
+
+        public static $selectMainMenu = ['xpath' => '//select[@id="menutype"]/option[@value="mainmenu"]'];
+
+        public static $homeButton = ['id' => 'toolbar-default'];
+
+        public static $checkInButton = ['id' => 'toolbar-checkin'];
+
+        public static $selectCategory = ['xpath' => '//*[@id="jform_request_catid"]/option[2]'];
+
+        /**
+        * Drop Down Toggle Element.
+        *
+        * @var    array
+        * @since  __DEPLOY_VERSION__
+        */
+        public static $dropDownToggle = ['xpath' => "//button[contains(@class, 'dropdown-toggle')]"];
+
+        /**
+         * Selecting category or article
+         *
+         * @var    array
+         * @since  __DEPLOY_VERSION__
+         */
+        public static $select = ['id' => 'jform_request_id_select'];
+
+        public static $selectMenuType = ['xpath' => '//select[@id=\'jform_request_id\']'];
+
+}
+

--- a/src/_support/Page/Acceptance/Administrator/frontEnd.php
+++ b/src/_support/Page/Acceptance/Administrator/frontEnd.php
@@ -1,0 +1,11 @@
+<?php
+    namespace Page\Acceptance\Administrator;
+
+    class frontEnd
+    {
+    // include url of current page
+
+        public static $urlfront = 'index.php';
+
+
+    }

--- a/src/_support/Page/Acceptance/Site/FrontPage.php
+++ b/src/_support/Page/Acceptance/Site/FrontPage.php
@@ -24,7 +24,7 @@ class FrontPage extends \AcceptanceTester
 	 * @var    string
 	 * @since  3.7.3
 	 */
-	public static $url = '/';
+	public static $url = 'index.php';
 
 	/**
 	 * Locator for alert message in frontend.

--- a/src/_support/Step/Acceptance/Administrator/Content.php
+++ b/src/_support/Step/Acceptance/Administrator/Content.php
@@ -3,13 +3,13 @@
  * @package     Joomla.Test
  * @subpackage  AcceptanceTester.Step
  *
- * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 namespace Step\Acceptance\Administrator;
 
-use Page\Acceptance\Administrator\ContentListPage;
+use Page\Acceptance\Administrator\ArticleManagerPage;
 
 /**
  * Acceptance Step object class contains suits for Content Manager.
@@ -20,56 +20,67 @@ use Page\Acceptance\Administrator\ContentListPage;
  */
 class Content extends Admin
 {
-	/**
-	 * Helper function to create a new Article
-	 *
-	 * @param   string  $title
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
+
+	public function createArticle($title, $body, $category)
+	{
+		$I = $this;
+		$I->amOnPage(ArticleManagerPage::$url);
+		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
+		$I->clickToolbarButton('New');
+		$this->articleManagerPage->fillContentCreateForm($title, $body);
+        	if($category!='null'){
+        	    $I->click(ArticleManagerPage::$selectCategory);
+        	    $I->fillField(ArticleManagerPage::$fillCategory,$category);
+	            $I->pressKey(ArticleManagerPage::$fillCategory,\Facebook\WebDriver\WebDriverKeys::ENTER);
+      	 	}
+		$I->click(ArticleManagerPage::$dropDownToggle);
+		$I->clickToolbarButton('Save & Close');
+		$I->articleManagerPage->seeItemIsCreated($title);
+	}
+
 	public function featureArticle($title)
 	{
 		$I = $this;
-		$I->amOnPage(ContentListPage::$url);
-		$I->waitForElement(ContentListPage::$filterSearch, TIMEOUT);
+		$I->amOnPage(ArticleManagerPage::$url);
+		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
 		$I->searchForItem($title);
 		$I->checkAllResults();
 		$I->clickToolbarButton('feature');
-		$I->seeNumberOfElements(ContentListPage::$seeFeatured, 1);
+		$I->seeNumberOfElements(ArticleManagerPage::$seeFeatured, 1);
 	}
 
 	public function setArticleAccessLevel($title, $accessLevel)
 	{
 		$I = $this;
-		$I->amOnPage(ContentListPage::$url);
-		$I->waitForElement(ContentListPage::$filterSearch, TIMEOUT);
+		$I->amOnPage(ArticleManagerPage::$url);
+		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
 		$I->searchForItem($title);
 		$I->checkAllResults();
 		$I->click($title);
 		$I->waitForElement(['id' => "jform_access"], TIMEOUT);
 		$I->selectOption(['id' => "jform_access"], $accessLevel);
-		$I->click(ContentListPage::$dropDownToggle);
+		$I->click(ArticleManagerPage::$dropDownToggle);
 		$I->clickToolbarButton('Save & Close');
-		$I->waitForElement(ContentListPage::$filterSearch, TIMEOUT);
-		$I->see($accessLevel, ContentListPage::$seeAccessLevel);
+		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
+		$I->see($accessLevel, ArticleManagerPage::$seeAccessLevel);
 	}
 
 	public function unPublishArticle($title)
 	{
 		$I = $this;
-		$I->amOnPage(ContentListPage::$url);
-		$I->waitForElement(ContentListPage::$filterSearch, TIMEOUT);
+		$I->amOnPage(ArticleManagerPage::$url);
+		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
 		$I->searchForItem($title);
 		$I->checkAllResults();
 		$I->clickToolbarButton('unpublish');
-		$I->seeNumberOfElements(ContentListPage::$seeUnpublished, 1);
+		$I->seeNumberOfElements(ArticleManagerPage::$seeUnpublished, 1);
 	}
 
 	public function trashArticle($title)
 	{
 		$I = $this;
-		$I->amOnPage(ContentListPage::$url);
-		$I->waitForElement(ContentListPage::$filterSearch, TIMEOUT);
+		$I->amOnPage(ArticleManagerPage::$url);
+		$I->waitForElement(ArticleManagerPage::$filterSearch, TIMEOUT);
 		$this->articleManagerPage->haveItemUsingSearch($title);
 		$I->clickToolbarButton('trash');
 		$I->searchForItem($title);

--- a/src/_support/Step/Acceptance/Site/FrontEnd.php
+++ b/src/_support/Step/Acceptance/Site/FrontEnd.php
@@ -1,0 +1,44 @@
+<?php
+    namespace Step\Acceptance\Site;
+
+    use Page\Acceptance\Site\FrontPage as FrontPage;
+
+    class FrontEnd extends \AcceptanceTester
+    {
+
+        /**
+         * Check whether Item is not Visible on front end
+         *
+         * @param \AcceptanceTester $I
+         * @param $menuItemName
+         *
+         * @return void
+         */
+        public static function notVisible(\AcceptanceTester $I, $menuItemName)
+        {
+
+            $I->comment('Make sure the menu item is not on site After unpublishing it');
+            $I->amOnPage(FrontPage::$url);
+
+            $I->dontSee($menuItemName);
+
+        }
+        /**
+         * Check whether Item is Visible on front end
+         *
+         * @param \AcceptanceTester $I
+         * @param $menuItemName
+         *
+         * @return void
+         */
+        public static function isVisible(\AcceptanceTester $I, $menuItemName)
+        {
+
+            $I->comment('Check the menu item on site After publishing it');
+            $I->amOnPage(FrontPage::$url);
+
+            $I->see($menuItemName);
+
+        }
+
+    }

--- a/src/acceptance/administrator/components/com_category_menu/CategoryMenuCest.php
+++ b/src/acceptance/administrator/components/com_category_menu/CategoryMenuCest.php
@@ -10,25 +10,38 @@
 
     use Step\Acceptance\Administrator\Category as CategoryStep;
     use Step\Acceptance\Administrator\Content as ContentStep;
+    use Step\Acceptance\Site\FrontEnd as FrontEnd;
     use Page\Acceptance\Administrator;
-    use Faker\Factory as fakerLib;
 
     class CategoryMenuCest
     {
 
+        /**
+         * CategoryMenuCest constructor.
+	 *
+	 * No parameters
+	 *
+	 *@return void
+         */
         public function __construct()
         {
 
             $faker = fakerLib::create();
 
-            $this->categoryTitle = $faker->name;
-            $this->articleTitle = $faker->name;
-            $this->articleContent = $faker->text;
-            $this->menuItemName = $faker->name;
-            $this->menuItemAlias = $faker->userName;
+            $this->categoryTitle  = 'COUNTRY';
+            $this->articleTitle   = 'ARTICLE INDIA';
+            $this->articleContent = 'This is test Article on country India';
+            $this->menuItemName   = 'India';
+            $this->menuItemAlias  = 'in';
 
         }
 
+        /**
+         * Create Category
+         *
+         * @param \AcceptanceTester $I
+         * @param $scenario
+         */
         public function Category(\AcceptanceTester $I, $scenario)
         {
 
@@ -39,6 +52,12 @@
 
         }
 
+        /**
+         * Create Articles in Category
+         *
+         * @param \AcceptanceTester $I
+         * @param $scenario
+         */
         public function createArticles(\AcceptanceTester $I, $scenario)
         {
 
@@ -51,6 +70,15 @@
 
         }
 
+        /**
+         * Publish Menu Items
+         *
+         * @param  \AcceptanceTester $I
+         *
+         * @throws \Exception
+         *
+         * @return void
+         */
         public function createMenuForCategory(\AcceptanceTester $I)
         {
 
@@ -122,7 +150,13 @@
             $I->searchForItem($this->menuItemName);
 
         }
-
+        /**
+         * Unpublish Menu Items and check front end
+         *
+         * @param   \AcceptanceTester $I
+         *
+         * @return  void
+         */
         public function unpublishMenuItems(\AcceptanceTester $I)
         {
 
@@ -143,18 +177,17 @@
 
             $I->clickToolbarButton('unpublish');
 
-        }
-
-        public function checkInFrontEndUnpublish(\AcceptanceTester $I)
-        {
-
-            $I->comment('Make sure the menu item is not on site After unpublishing it');
-            $I->amOnPage(Administrator\frontEnd::$urlfront);
-
-            $I->dontSee($this->menuItemName);
+            //Check In FrontEnd
+            FrontEnd::notVisible($I,$this->menuItemName);
 
         }
-
+        /**
+         * Publish Menu Items
+         *
+         * @param   \AcceptanceTester $I
+         *
+         * @return  void
+         */
         public function publishMenuItems(\AcceptanceTester $I)
         {
 
@@ -176,18 +209,18 @@
             //publish
             $I->clickToolbarButton('publish');
 
-        }
+            //Check In FrontEnd
+            FrontEnd::isVisible($I,$this->menuItemName);
 
-        public function checkInFrontEndPublish(\AcceptanceTester $I)
-        {
-
-            $I->comment('Check the menu item on site After publishing it');
-            $I->amOnPage(Administrator\frontEnd::$urlfront);
-
-            $I->see($this->menuItemName);
 
         }
-
+        /**
+         * Set Menu Item To Home
+         *
+         * @param   \AcceptanceTester $I
+         *
+         * @return  void
+         */
         public function setMenuItemHome(\AcceptanceTester $I)
         {
 
@@ -208,18 +241,20 @@
             //Set To Home
             $I->click(Administrator\MenuItem::$homeButton);
 
-        }
-
-        public function checkInFrontEndSetHome(\AcceptanceTester $I)
-        {
-
-            $I->comment('Check the menu item on site After setting it to Home');
-            $I->amOnPage(Administrator\frontEnd::$urlfront);
-
-            $I->see($this->menuItemName);
+            //Check In FrontEnd
+            FrontEnd::isVisible($I,$this->menuItemName);
 
         }
 
+        /**
+         * Rebuild Menu Items
+         *
+         * @param   \AcceptanceTester $I
+         *
+         * @return  void
+         *
+         * @since   3.8.3
+         */
         public function rebuildMenuItems(\AcceptanceTester $I)
         {
 
@@ -243,18 +278,16 @@
             // Success message
             $I->see('Menu items list rebuilt', Administrator\AdminPage::$systemMessageContainer);
 
+            //Check In FrontEnd
+            FrontEnd::isVisible($I,$this->menuItemName);
         }
-
-        public function checkInFrontEndRebuild(\AcceptanceTester $I)
-        {
-
-            $I->comment('Check the menu item on site After rebuilding');
-            $I->amOnPage(Administrator\frontEnd::$urlfront);
-
-            $I->see($this->menuItemName);
-
-        }
-
+        /**
+         * Trash Menu Items
+         *
+         * @param   \AcceptanceTester $I
+         *
+         * @return  void
+         */
         public function trashMenuItems(\AcceptanceTester $I)
         {
 
@@ -280,17 +313,8 @@
 
             $I->clickToolbarButton('trash');
 
-            $I->see('1 menu item trashed.', Administrator\AdminPage::$systemMessageContainer);
-        }
-
-        public function checkInFrontEndTrash(\AcceptanceTester $I)
-        {
-
-            $I->comment('Check the menu item on site After rebuilding');
-            $I->amOnPage(Administrator\frontEnd::$urlfront);
-
-            $I->dontSee($this->menuItemName);
-
+            //Check In FrontEnd
+            FrontEnd::notVisible($I,$this->menuItemName);
         }
 
     }

--- a/src/acceptance/administrator/components/com_category_menu/CategoryMenuCest.php
+++ b/src/acceptance/administrator/components/com_category_menu/CategoryMenuCest.php
@@ -1,0 +1,296 @@
+<?php
+    /**
+     * @package     Joomla.Tests
+     * @subpackage  Acceptance.tests
+     *
+     * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+     * @license     GNU General Public License version 2 or later; see LICENSE.txt
+     */
+    namespace administrator\components\com_category_menu;
+
+    use Step\Acceptance\Administrator\Category as CategoryStep;
+    use Step\Acceptance\Administrator\Content as ContentStep;
+    use Page\Acceptance\Administrator;
+    use Faker\Factory as fakerLib;
+
+    class CategoryMenuCest
+    {
+
+        public function __construct()
+        {
+
+            $faker = fakerLib::create();
+
+            $this->categoryTitle = $faker->name;
+            $this->articleTitle = $faker->name;
+            $this->articleContent = $faker->text;
+            $this->menuItemName = $faker->name;
+            $this->menuItemAlias = $faker->userName;
+
+        }
+
+        public function Category(\AcceptanceTester $I, $scenario)
+        {
+
+            $I = new CategoryStep($scenario);
+
+            $I->doAdministratorLogin();
+            $I->createContentCategory($this->categoryTitle);
+
+        }
+
+        public function createArticles(\AcceptanceTester $I, $scenario)
+        {
+
+            $I = new ContentStep($scenario);
+
+            for ($j=0;$j<2;$j++) {
+                $I->doAdministratorLogin();
+                $I->createArticle($this->articleTitle.$j, $this->articleContent, $this->categoryTitle);
+            }
+
+        }
+
+        public function createMenuForCategory(\AcceptanceTester $I)
+        {
+
+            $I->comment('I am going to create a menu item');
+            $I->doAdministratorLogin();
+
+
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
+
+            $I->waitForText(Administrator\MenuItem::$pageTitleText);
+
+            /**
+             * Creating A New Menu item
+             *  1. click on "new" botton
+             *  2. fill the Menu Select type
+             *  3. fill two fields : menu item name and alias
+             *  4. click on "save" button
+             */
+
+            $I->click(['id' => "menu-collapse"]);
+
+            $I->clickToolbarButton('new');
+
+
+            $I->fillField(Administrator\MenuItem::$menuItemTitle, $this->menuItemName);
+            $I->fillField(Administrator\MenuItem::$menuItemAlias, $this->menuItemAlias);
+
+            $I->waitForText('Select');
+
+            $I->click('Select');
+            $I->checkForPhpNoticesOrWarnings();
+            $I->switchToIFrame();
+            $I->waitForElement(Administrator\MenuItem::$menuTypeModal, TIMEOUT);
+            $I->switchToIFrame("Menu Item Type");
+            $I->waitForElement(Administrator\MenuItem::$articlesLink, TIMEOUT);
+            $I->click(['link' => 'Articles']);
+
+            /**
+             * Options under Articles
+             * Archived Article
+             * Featured Article
+             * Create Article
+             * Category Blog
+             * Category List
+             * List All Categories  <- We chose this Option
+             * Single Article
+             */
+            $I->wait(.5);
+            $I->waitForElement( "//div[contains(text(), 'List All Categories')]", TIMEOUT);
+            $I->scrollTo("//div[contains(text(), 'List All Categories')]");
+            $I->click("//div[contains(text(), 'List All Categories')]");
+
+            //Select Option
+            $I->selectOption(Administrator\MenuItem::$selectMenuType,$this->categoryTitle);
+
+            //Select option from dropdown menu
+            $I->click(Administrator\MenuItem::$menuDropDown);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectOption);
+            $I->selectOption(Administrator\MenuItem::$menuDropDown, $option);
+
+            //Save the menu item
+            $I->click(Administrator\MenuItem::$dropDownToggle);
+            $I->clickToolbarButton('save & close');
+
+            // Success message
+            $I->see(Administrator\MenuItem::$successMessage, Administrator\AdminPage::$systemMessageContainer);
+
+            $I->searchForItem($this->menuItemName);
+
+        }
+
+        public function unpublishMenuItems(\AcceptanceTester $I)
+        {
+
+            $I->comment('I am going to unpublish a menu');
+            $I->doAdministratorLogin();
+
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
+
+            //Select 'Main Menu'
+            $I->click(Administrator\MenuItem::$selectMenu);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+            $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+
+            //Search For Menu Item
+            $I->searchForItem($this->menuItemName);
+            $I->click(Administrator\MenuItem::$check);
+
+            $I->clickToolbarButton('unpublish');
+
+        }
+
+        public function checkInFrontEndUnpublish(\AcceptanceTester $I)
+        {
+
+            $I->comment('Make sure the menu item is not on site After unpublishing it');
+            $I->amOnPage(Administrator\frontEnd::$urlfront);
+
+            $I->dontSee($this->menuItemName);
+
+        }
+
+        public function publishMenuItems(\AcceptanceTester $I)
+        {
+
+            $I->comment('I am going to publish a menu');
+            $I->doAdministratorLogin();
+
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
+
+            //Set Menu To 'Main Menu'
+            $I->click(Administrator\MenuItem::$selectMenu);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+            $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+
+            //Search for Menu item
+            $I->searchForItem($this->menuItemName);
+            $I->click(Administrator\MenuItem::$check);
+
+            //publish
+            $I->clickToolbarButton('publish');
+
+        }
+
+        public function checkInFrontEndPublish(\AcceptanceTester $I)
+        {
+
+            $I->comment('Check the menu item on site After publishing it');
+            $I->amOnPage(Administrator\frontEnd::$urlfront);
+
+            $I->see($this->menuItemName);
+
+        }
+
+        public function setMenuItemHome(\AcceptanceTester $I)
+        {
+
+            $I->comment('I am going to set a menu item home');
+            $I->doAdministratorLogin();
+
+            $I->amOnPage(Administrator\MenuItem::$url);
+
+            //Set Menu To 'Main Menu'
+            $I->click(Administrator\MenuItem::$selectMenu);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+            $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+
+            //Search for Menu item
+            $I->searchForItem($this->menuItemName);
+            $I->click(Administrator\MenuItem::$check);
+
+            //Set To Home
+            $I->click(Administrator\MenuItem::$homeButton);
+
+        }
+
+        public function checkInFrontEndSetHome(\AcceptanceTester $I)
+        {
+
+            $I->comment('Check the menu item on site After setting it to Home');
+            $I->amOnPage(Administrator\frontEnd::$urlfront);
+
+            $I->see($this->menuItemName);
+
+        }
+
+        public function rebuildMenuItems(\AcceptanceTester $I)
+        {
+
+            $I->comment('I am going to rebuild a menu item');
+            $I->doAdministratorLogin();
+
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
+
+            //Set Menu To 'Main Menu'
+            $I->click(Administrator\MenuItem::$selectMenu);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+            $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+
+            //Search for Menu item
+            $I->searchForItem($this->menuItemName);
+            $I->click(Administrator\MenuItem::$check);
+
+            $I->clickToolbarButton('rebuild');
+
+            // Success message
+            $I->see('Menu items list rebuilt', Administrator\AdminPage::$systemMessageContainer);
+
+        }
+
+        public function checkInFrontEndRebuild(\AcceptanceTester $I)
+        {
+
+            $I->comment('Check the menu item on site After rebuilding');
+            $I->amOnPage(Administrator\frontEnd::$urlfront);
+
+            $I->see($this->menuItemName);
+
+        }
+
+        public function trashMenuItems(\AcceptanceTester $I)
+        {
+
+            $I->comment('I am going to trash a menu item');
+            $I->doAdministratorLogin();
+
+            $I->amOnPage(Administrator\MenuItem::$url);
+            $I->checkForPhpNoticesOrWarnings();
+
+            //Set Menu To 'Main Menu'
+            $I->click(Administrator\MenuItem::$selectMenu);
+            $option = $I->grabTextFrom(Administrator\MenuItem::$selectMainMenu);
+            $I->selectOption(Administrator\MenuItem::$selectMenu, $option);
+
+            //Set 'Home' To Home To Trash
+            $I->searchForItem('Home');
+            $I->click(Administrator\MenuItem::$check);
+            $I->click(Administrator\MenuItem::$homeButton);
+
+            //Search for Menu item
+            $I->searchForItem($this->menuItemName);
+            $I->click(Administrator\MenuItem::$check);
+
+            $I->clickToolbarButton('trash');
+
+            $I->see('1 menu item trashed.', Administrator\AdminPage::$systemMessageContainer);
+        }
+
+        public function checkInFrontEndTrash(\AcceptanceTester $I)
+        {
+
+            $I->comment('Check the menu item on site After rebuilding');
+            $I->amOnPage(Administrator\frontEnd::$urlfront);
+
+            $I->dontSee($this->menuItemName);
+
+        }
+
+    }

--- a/src/acceptance/administrator/components/com_users/UserListCest.php
+++ b/src/acceptance/administrator/components/com_users/UserListCest.php
@@ -135,7 +135,7 @@ class UserListCest
 		$I->comment('I wait for error reporting dropdown');
 		$I->click(['xpath' => "//input[@type='radio' and @value=0 and @name='jform[mailonline]']"]);
 		$I->comment('I click on save');
-		$I->click(['id' => 'toolbar-apply']);
+		$I->clickToolbarButton("Save");
 		$I->comment('I wait for global configuration being saved');
 		$I->waitForText('Global Configuration', TIMEOUT, ['css' => '.page-title']);
 		$I->see('Configuration saved.', ['id' => 'system-message-container']);


### PR DESCRIPTION
Steps : 
1. created category
2. created 2 articles in that category 
3. created a menu item of Menu Item Type : 'List Of Category'  
4. unpublished the menu item and checked on front end
5. published the menu item and checked on front end
6. set the menu item and checked on front end
7. Rebuild menu items
8. Trash the menu item and check on front end

Left Over : 
1.  I need to change the Menu Item Type to 'Category Blog' so that Articles are visible on front end but I am facing issue with selecting link on iframe
2. check front end while publishing and unpublishing articles .
3. Add comments to each function
4. Make 'checkInFrontEnd' A Step function

The second one is not a big task, there are functions for that in Content.php(step). I will be able to do that as soon as the first one gets solved.
