### PR TITLE
Menu And UserCest

### DIFF
--- a/src/_support/Page/Acceptance/Administrator/UserListPage.php
+++ b/src/_support/Page/Acceptance/Administrator/UserListPage.php
@@ -33,15 +33,7 @@ class UserListPage extends AdminListPage
 	 * @since  3.7.3
 	 */
 	public static $pageTitleText = "Users";
-
-	/**
-	 * New User Button
-	 *
-	 * @var    string
-	 * @since  3.7.3
-	 */
-	public static $newButton = ['class' => 'button-new'];
-
+	
 	/**
 	 * Edit Button
 	 *

--- a/src/acceptance/administrator/components/com_menu/MenuCest.php
+++ b/src/acceptance/administrator/components/com_menu/MenuCest.php
@@ -36,7 +36,7 @@ class MenuCest
 		$I->checkForPhpNoticesOrWarnings();
 
 		$I->waitForText(MenuListPage::$pageTitleText);
-		$I->click(['id' => "menu-collapse"]);
+		$I->click('#menu-collapse-icon');
 
 		$I->clickToolbarButton('new');
 		$I->waitForText(MenuFormPage::$pageTitleText);

--- a/src/acceptance/administrator/components/com_users/UserListCest.php
+++ b/src/acceptance/administrator/components/com_users/UserListCest.php
@@ -45,7 +45,7 @@ class UserListCest
 
 		$I->waitForText(UserListPage::$pageTitleText);
 
-		$I->click(UserListPage::$newButton);
+		$I->clickToolbarButton('new');
 
 		$I->waitForElement(UserListPage::$accountDetailsTab);
 		$I->checkForPhpNoticesOrWarnings();
@@ -131,9 +131,9 @@ class UserListCest
 		$I->amOnPage('/administrator/index.php?option=com_config');
 		$I->waitForText('Global Configuration', TIMEOUT, ['css' => '.page-title']);
 		$I->comment('I open the Server Tab');
-		$I->click(['link' => 'Server']);
+		$I->click('Server');
 		$I->comment('I wait for error reporting dropdown');
-		$I->click(['xpath' => "//input[@type='radio' and @value=0 and @name='jform[mailonline]']"]);
+		$I->click(['xpath' => "//input[@id='jform_mailonline1']"]);
 		$I->comment('I click on save');
 		$I->clickToolbarButton("Save");
 		$I->comment('I wait for global configuration being saved');


### PR DESCRIPTION
added menu collapse Just a small change to solve error.
Cause of error,
![selection_007](https://user-images.githubusercontent.com/19748816/42385127-839d3544-8159-11e8-92b5-1b384aa828cb.png)

You need to use #menu-collapse-icon as id instead of #menu-collapse
This is small PR for new test template