### PR TITLE
Make category drop down toggle more specific

### DIFF
--- a/src/_support/Page/Acceptance/Administrator/ContentCategoryListPage.php
+++ b/src/_support/Page/Acceptance/Administrator/ContentCategoryListPage.php
@@ -26,7 +26,7 @@ class ContentCategoryListPage extends AdminListPage
 	 */
 	public static $url = '/administrator/index.php?option=com_categories&view=categories&extension=com_content';
 
-	public static $dropDownToggle = ['xpath' => "//button[contains(@class, 'dropdown-toggle')]"];
+	public static $dropDownToggle = ['xpath' => "//div[@id='toolbar-dropdown-save-group']/button[contains(@class, 'dropdown-toggle')]"];
 
 	/**
 	 * Locator for category name field


### PR DESCRIPTION
In the new backend template the toggle isn't specific enough as there is a dropdown toggle at the template level for postinstallation messages. This ensures we select the save toolbar toggle (this works with both the new backend template and existing one)